### PR TITLE
Made `DispatchFuture` accessible through `Provider.of`

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,8 @@ The `AsyncReduxProvider` widget above will expose the store, the state, and the 
 * The store's state, of type `AppState`. Get it like this: `Provider.of<AppState>(context)`.
 
 * The dispatch method, of type `Dispatch`. Get it like this: `Provider.of<Dispatch>(context)`.
+
+* The async dispatch method, of type `DispatchFuture`. Get it like this: `Provider.of<DispatchFuture>(context)`.
            
 This is a complete example:
 

--- a/lib/provider_for_redux.dart
+++ b/lib/provider_for_redux.dart
@@ -33,6 +33,7 @@ import 'package:provider/single_child_widget.dart';
 /// Provider.of<Store<AppState>>(context) to get the store.
 /// Provider.of<AppState>(context) to get the state.
 /// Provider.of<Dispatch>(context) to get the dispatch method.
+/// Provider.of<DispatchFuture>(context) to get the async dispatch method.
 /// ```
 ///
 /// Example of using `state` and `dispatch`:
@@ -113,6 +114,9 @@ class _AsyncReduxProviderState<St> extends State<AsyncReduxProvider<St>> {
           //
           // The dispatch method:  -------------
           Provider<Dispatch>.value(value: _store.dispatch),
+          //
+          // The async dispatch method:  -------------
+          Provider<DispatchFuture>.value(value: _store.dispatchFuture),
           //
         ],
         //


### PR DESCRIPTION
Hi.

In my case, I often want to access `DispatchFuture` through `Provider.of` like this:

```dart
Future<void> someFunction(BuildContext context) async {
  await context.read<DispatchFuture>()(MyAction1());
  await context.read<DispatchFuture>()(MyAction2());
}
```

So, I made a modification so that `provider_for_redux` would provide `DispatchFuture` using `Provider.value`.

Could you take a look at this PR? 
Sincerely.